### PR TITLE
Add dash character to alias regexp

### DIFF
--- a/ftplugin/taxi.vim
+++ b/ftplugin/taxi.vim
@@ -1,7 +1,7 @@
 " Set the omnifunc to be able to complete the aliases via <ctrl-x> <ctrl-o>
 set omnifunc=TaxiAliases
 set completeopt+=longest
-let s:pat = '^\([a-zA-Z0-9_?]\+\)\s\+\([0-9:?-]\+\)\s\+\(.*\)$'
+let s:pat = '^\([a-zA-Z0-9_\-?]\+\)\s\+\([0-9:?-]\+\)\s\+\(.*\)$'
 " TODO is this a good cache location?
 let s:cache_file = $HOME."/.local/share/taxi/taxi_aliases"
 


### PR DESCRIPTION
This fix the issue https://github.com/schtibe/taxi.vim/issues/3 (lines containing an alias which contains a dash not being formatted)